### PR TITLE
Feature/cni

### DIFF
--- a/index_update.py
+++ b/index_update.py
@@ -55,6 +55,7 @@ def update_latest_dates(engine, latest_dates_df, info_name):
         with engine.connect() as connection:
             with connection.begin() as transaction:
                 print(f"--- Starting update for '{info_name}' table ---")
+                latest_dates_df['latest_date'] = pd.to_datetime(latest_dates_df['latest_date']).dt.date
                 for index, row in latest_dates_df.iterrows():
                     code_to_update = row["code"]
                     new_date = row["latest_date"]

--- a/index_update.py
+++ b/index_update.py
@@ -46,9 +46,35 @@ def get_latest_dates(engine, table_name):
     return latest_dates_df
 
 
+def update_latest_dates(engine, latest_dates_df, info_name):
+    """更新bench_info_wind表中的最新日期，和bench_basic_data表中的最新日期同步"""
+    if latest_dates_df is None or latest_dates_df.empty:
+        print("没有数据提供. Skipping.")
+        return
+    try:
+        with engine.connect() as connection:
+            with connection.begin() as transaction:
+                print(f"--- Starting update for '{info_name}' table ---")
+                for index, row in latest_dates_df.iterrows():
+                    code_to_update = row["code"]
+                    new_date = row["latest_date"]
+                    update_query = text(
+                        f"UPDATE `{info_name}` SET `updated_date` = :new_date WHERE `code` = :code_val"
+                    )
+                    connection.execute(
+                        update_query, {"new_date": new_date, "code_val": code_to_update}
+                    )
+
+                print(
+                    f"成功更新 {len(latest_dates_df)} 条记录."
+                )
+    except Exception as e:
+        print(f"An error occurred during the update: {e}")
+
+
 def get_source_info(engine, info_name):
     """读取数据获取的参数信息"""
-    info_query = text(f"SELECT code, indexID, source FROM {info_name}")
+    info_query = text(f"SELECT code, updated_date, indexID, source FROM {info_name}")
     info_df = pd.read_sql_query(info_query, engine)
     return info_df
 
@@ -353,7 +379,9 @@ def main():
     # 执行数据处理流程
     engine = connect_to_database()
     latest_dates_df = get_latest_dates(engine, table_name)
+    update_latest_dates(engine, latest_dates_df, info_name)
     info_df = get_source_info(engine, info_name)
+    info_df['updated_date'] = pd.to_datetime(info_df['updated_date'])
 
     # 创建查询表
     symbols_ak = (
@@ -388,7 +416,7 @@ def main():
     # 初始化数据列表和日期
     all_new_data = []
     today_str = datetime.now().strftime("%Y%m%d")
-    latest_dates_dict = latest_dates_df.set_index("code")["latest_date"].to_dict()
+    latest_dates_dict = info_df.set_index("code")["updated_date"].to_dict()
 
     # 从各数据源获取数据
     all_new_data.extend(fetch_akshare_data(symbols_ak, latest_dates_dict, today_str))


### PR DESCRIPTION
@Euclid-Jie 欧老师下午好。

不好意思这个commit内容有点杂没有分清，内容如下：

我在进行绘图时要用到国证数据，按照以前的设想，应该可以直接在`bench_info_wind`中手动添加一行信息，就可以添加指数数据了。

但是运行时发现原始爬取文件中的逻辑下获取现有信息是在`bench_basic_data`中，由于是**新增信息**，`bench_basic_data`中没有数据，导致程序跳过其获取。

为了解决这个问题，做了以下修改，这样程序便能总是运行时先将`bench_info_wind`表中的`updated_date`列与数据表同步，然后数据部分所需信息从`bench_info_wind`表中获取，就能获得手动输入的信息了，也实现了更新日期的信息同步。

1. 添加了`update_latest_dates(engine, latest_dates_df, info_name)`函数，其作用是利用从`bench_basic_data`中获得的已有数据的最新日期，并更新到`bench_info_wind`表中的`updated_date`列中。
2. `get_source_info(engine, info_name)`获取的信息添加一列`updated_date`。
3. 主干部分爬取数据时用的日期初始日信息来源从`bench_basic_data`修改至`bench_info_wind`。
4. 在`bench_info_wind`中手动添加了**国证成长**和**国证价值**的指数信息，并运行获得了数据到`bench_basic_data`


<img width="1764" height="646" alt="d73762ecf48bba960b5126d6b7ba917a" src="https://github.com/user-attachments/assets/fb12df65-dccc-4157-bb8c-cdd065fadd8e" />
另外，添加一个新的指数时，要在`updated_date`列手动输入一个期望数据的开始日期。